### PR TITLE
Bump systeminformation version

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
   "homepage": "https://github.com/SalekurPolas/MMM-Pinfo#readme",
   "dependencies": {
     "async": "^3.2.5",
-    "systeminformation": "^5.21.24"
+    "systeminformation": "^5.25.11"
   }
 }


### PR DESCRIPTION
There is a vulnerability and a deprecation warning that comes with v5.23, bumping to latest.  Seems to work fine.