### PR TITLE
Define uptime to avoid error on initial load

### DIFF
--- a/MMM-Pinfo.js
+++ b/MMM-Pinfo.js
@@ -112,7 +112,8 @@ Module.register('MMM-Pinfo', {
                 type: 'Loading...',
                 usage: 0,
                 temp: 0
-            }
+            },
+          UPTIME: 'Loading...',
         }
 
         this.config = merge({}, this.defaults, this.config);


### PR DESCRIPTION
Sorry, one last tweak.

The module was throwing an error at initial load because I did not update `this.status` in the main js file to add the new uptime variable.