### PR TITLE
fix: return to old merge logic + formating

### DIFF
--- a/MMM-Pinfo.js
+++ b/MMM-Pinfo.js
@@ -116,7 +116,7 @@ Module.register('MMM-Pinfo', {
           UPTIME: 'Loading...',
         }
 
-        this.config = { ...this.defaults, ...this.config };
+        this.config = this.merge({}, this.defaults, this.config);
 
         if(this.data.position === 'top_left' || this.data.position === 'bottom_left') {
             this.config.itemAlign = 'flex-start';
@@ -653,4 +653,12 @@ Module.register('MMM-Pinfo', {
         this.updateDom();
         }
     },
+
+    merge: function(e) {
+        for (var o, t, r = Array.prototype.slice.call(arguments, 1); r.length;) {
+            o = r.shift();
+            for (t in o) o.hasOwnProperty(t) && ("object" == typeof e[t] && e[t] && "[object Array]" !== Object.prototype.toString.call(e[t]) && "object" == typeof o[t] && null !== o[t] ? e[t] = configMerge({}, e[t], o[t]) : e[t] = o[t]);
+        }
+        return e;
+    }
 });

--- a/MMM-Pinfo.js
+++ b/MMM-Pinfo.js
@@ -11,65 +11,65 @@ Module.register('MMM-Pinfo', {
         containerSize: null,
         header: 'Mirror Information',
 
-    DEVICE: {
-        labelModel: "Model",
-        displayModel: true,
-        orderModel: 1,
+        DEVICE: {
+            labelModel: "Model",
+            displayModel: true,
+            orderModel: 1,
 
-        labelSerial: 'Serial',
-        displaySerial: true,
-        orderSerial: 2
+            labelSerial: 'Serial',
+            displaySerial: true,
+            orderSerial: 2
         },
         OS: {
-        labelOs: 'OS',
-        displayOs: false,
-        orderOs: 3
+            labelOs: 'OS',
+            displayOs: false,
+            orderOs: 3
         },
         NETWORK: {
-        labelType: 'NET Type',
-        displayType: false,
-        orderType: 4,
+            labelType: 'NET Type',
+            displayType: false,
+            orderType: 4,
 
-        labelIPv4: 'IPv4',
-        displayIPv4: true,
-        orderIPv4: 5,
+            labelIPv4: 'IPv4',
+            displayIPv4: true,
+            orderIPv4: 5,
 
-        labelIPv6: 'IPv6',
-        displayIPv6: false,
-        orderIPv6: 6,
+            labelIPv6: 'IPv6',
+            displayIPv6: false,
+            orderIPv6: 6,
 
-        labelMac: 'MAC',
-        displayMac: false,
-        orderMac: 7
+            labelMac: 'MAC',
+            displayMac: false,
+            orderMac: 7
         },
         RAM: {
-        labelRam: 'RAM',
+            labelRam: 'RAM',
             displayRam: true,
             orderRam: 8
         },
         STORAGE: {
-        labelStorage: 'Storage',
+            labelStorage: 'Storage',
             displayStorage: true,
             orderStorage: 9,
         },
-    CPU: {
-      labelType: 'CPU Type',
-      displayType: false,
-      orderType: 10,
+        CPU: {
+            labelType: 'CPU Type',
+            displayType: false,
+            orderType: 10,
 
-      labelUsage: 'CPU Usage',
-      displayUsage: false,
-      orderUsage: 11,
+            labelUsage: 'CPU Usage',
+            displayUsage: false,
+            orderUsage: 11,
 
-      labelTemp: 'CPU Temp',
-      displayTemp: true,
-      orderTemp: 12
-    },
-    UPTIME: {
-      labelUptime: 'Uptime',
-      displayUptime: false,
-      orderUptime: 13,
-    },
+            labelTemp: 'CPU Temp',
+            displayTemp: true,
+            orderTemp: 12
+        },
+        UPTIME: {
+            labelUptime: 'Uptime',
+            displayUptime: false,
+            orderUptime: 13,
+        },
         WARNING: {
             enable: false,
             interval: 1000 * 60 * 5,
@@ -87,16 +87,16 @@ Module.register('MMM-Pinfo', {
         this.container = 0;
         
         this.status = {
-        DEVICE: {
-        model: 'Loading...',
-        serial: 'Loading...'
+            DEVICE: {
+                model: 'Loading...',
+                serial: 'Loading...'
             },
             OS: 'Loading...',
             NETWORK: {
-        type: 'Loading...',
-        ipv4: 'Loading...',
-        ipv6: 'Loading...',
-        mac: 'Loading...'
+                type: 'Loading...',
+                ipv4: 'Loading...',
+                ipv6: 'Loading...',
+                mac: 'Loading...'
             },
             MEMORY: {
                 total: 0,
@@ -113,7 +113,7 @@ Module.register('MMM-Pinfo', {
                 usage: 0,
                 temp: 0
             },
-          UPTIME: 'Loading...',
+            UPTIME: 'Loading...',
         }
 
         this.config = this.merge({}, this.defaults, this.config);

--- a/README.md
+++ b/README.md
@@ -399,95 +399,94 @@ To setup `MMM-Pinfo` module in MagicMirror², add the following section to the `
 ## Default Configuration
 
 ```js
-{
-  module: 'MMM-Pinfo',
-  position: 'top_left',
-  config: {
-    debug: true,
-    refresh: 5000,
-    itemAlign: 'left',
-    labelAlign: 'left',
-    valueAlign: 'center',
-    labelSize: null,
-    containerSize: null,
+  {
+    module: 'MMM-Pinfo',
+    position: 'top_left',
+    config: {
+      debug: true,
+      refresh: 5000,
+      itemAlign: 'left',
+      labelAlign: 'left',
+      valueAlign: 'center',
+      labelSize: null,
+      containerSize: null,
 
-    DEVICE: {
-      labelModel: "Model",
-      displayModel: true,
-      orderModel: 1,
+      DEVICE: {
+        labelModel: "Model",
+        displayModel: true,
+        orderModel: 1,
 
-      labelSerial: 'Serial',
-      displaySerial: true,
-      orderSerial: 2
-    },
+        labelSerial: 'Serial',
+        displaySerial: true,
+        orderSerial: 2
+      },
 
-    OS: {
-      labelOs: 'OS',
-      displayOs: false,
-      orderOs: 3
-    },
+      OS: {
+        labelOs: 'OS',
+        displayOs: false,
+        orderOs: 3
+      },
 
-    NETWORK: {
-      labelType: 'NET Type',
-      displayType: false,
-      orderType: 4,
+      NETWORK: {
+        labelType: 'NET Type',
+        displayType: false,
+        orderType: 4,
 
-      labelIPv4: 'IPv4',
-      displayIPv4: true,
-      orderIPv4: 5,
+        labelIPv4: 'IPv4',
+        displayIPv4: true,
+        orderIPv4: 5,
 
-      labelIPv6: 'IPv6',
-      displayIPv6: false,
-      orderIPv6: 6,
+        labelIPv6: 'IPv6',
+        displayIPv6: false,
+        orderIPv6: 6,
 
-      labelMac: 'MAC',
-      displayMac: false,
-      orderMac: 7
-    },
+        labelMac: 'MAC',
+        displayMac: false,
+        orderMac: 7
+      },
 
-    RAM: {
-      labelRam: 'RAM',
-      displayRam: true,
-      orderRam: 8
-    },
+      RAM: {
+        labelRam: 'RAM',
+        displayRam: true,
+        orderRam: 8
+      },
 
-    STORAGE: {
-      labelStorage: 'Storage',
-      displayStorage: true,
-      orderStorage: 9,
-    },
+      STORAGE: {
+        labelStorage: 'Storage',
+        displayStorage: true,
+        orderStorage: 9,
+      },
 
-    CPU: {
-      labelType: 'CPU Type',
-      displayType: false,
-      orderType: 10,
+      CPU: {
+        labelType: 'CPU Type',
+        displayType: false,
+        orderType: 10,
 
-      labelUsage: 'CPU Usage',
-      displayUsage: false,
-      orderUsage: 11,
+        labelUsage: 'CPU Usage',
+        displayUsage: false,
+        orderUsage: 11,
 
-      labelTemp: 'CPU Temp',
-      displayTemp: true,
-      orderTemp: 12
-    },
-   CPU: {
-      labelUptime: 'Uptime',
-      displayUptime: false,
-      orderUptime: 13
-    },
-
-    WARNING: {
-      enable: false,
-      interval: 1000 * 60 * 5,
-      check: {
-        CPU_TEMP: 65,
-        CPU_USAGE: 75,
-        RAM_USED: 80,
-        STORAGE_USED: 80
-      }
-    },
-  }
-}
+        labelTemp: 'CPU Temp',
+        displayTemp: true,
+        orderTemp: 12
+      },
+      CPU: {
+          labelUptime: 'Uptime',
+          displayUptime: false,
+          orderUptime: 13
+        },
+      WARNING: {
+        enable: false,
+        interval: 1000 * 60 * 5,
+        check: {
+          CPU_TEMP: 65,
+          CPU_USAGE: 75,
+          RAM_USED: 80,
+          STORAGE_USED: 80
+        }
+      },
+    }
+  },
 ```
 
 ## Issues

--- a/README.md
+++ b/README.md
@@ -470,7 +470,7 @@ To setup `MMM-Pinfo` module in MagicMirror², add the following section to the `
         displayTemp: true,
         orderTemp: 12
       },
-      CPU: {
+      UPTIME: {
           labelUptime: 'Uptime',
           displayUptime: false,
           orderUptime: 13


### PR DESCRIPTION
With #22 I introduced a bug by refactoring the config merging using a spread operator. This PR reintroduces the old merge logic and optimizes a few formatting details.

The old merge logic could definitely be simplified, but I would need a bit more time for that. 

Sorry for any inconvenience.